### PR TITLE
Add tab stops.

### DIFF
--- a/template.txt
+++ b/template.txt
@@ -1,7 +1,7 @@
 001                                                                             PAGE 0
 002     000 000 LABEL:  INSTRUCTION     ;COMMENT
 003
-004
+004                     ;TAB    ;STOPS  ;       ;       ;       ;       ;
 005
 006
 007


### PR DESCRIPTION
Comments virtually always begin at tabs stops.  This is where they should be.